### PR TITLE
Add environment setup and demo scripts

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Setup script for Codex environment
+# Installs dependencies and downloads dataset before network access is disabled
+
+set -e
+
+# Install Python dependencies
+if [ -f requirements.txt ]; then
+    pip install -r requirements.txt
+fi
+
+# Install package in editable mode
+pip install -e .
+
+# Download dataset repository and copy NELL-995
+if [ ! -d "KB-Reasoning-Data" ]; then
+    git clone https://github.com/wenhuchen/KB-Reasoning-Data.git
+fi
+cp -r KB-Reasoning-Data/NELL-995 ./
+

--- a/demo.sh
+++ b/demo.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Demonstration script for DeepPath
+# Assumes dependencies and dataset are already installed via .codex/setup.sh
+
+set -e
+
+RELATION=${1:-athletePlaysForTeam}
+
+# Run training and testing for the provided relation
+./pathfinder.sh "$RELATION"


### PR DESCRIPTION
## Summary
- add `.codex/setup.sh` so Codex can install dependencies and fetch the dataset before network access is disabled
- add `demo.sh` to run a training/testing demo using `pathfinder.sh`

## Testing
- `git status --short`